### PR TITLE
Script to batch change the SVN url of a job using regular expressions

### DIFF
--- a/scriptler/svnChangeBranch.groovy
+++ b/scriptler/svnChangeBranch.groovy
@@ -8,8 +8,15 @@
   ]
 } END META**/
 
+/*
+ * Based on http://scriptlerweb.appspot.com/script/show/48001
+ * 
+ * Currently largely untested, although it seems to work, check your results!
+ */
+
 import hudson.scm.*
 
+// Default to replacing the part after .../branches/ with the value of newBranch.
 if(null == oldBranch || "".equals(oldBranch)) {
   oldBranch = "/branches/([^/])*/"
   newBranch = "/branches/$newBranch/"


### PR DESCRIPTION
Base usage is to quickly switch a set of jobs to a different branch. But other url changes should be possible.
