### PR TITLE
Filter job list before applying hashify

### DIFF
--- a/scriptler/hashifyAllScmTriggers.groovy
+++ b/scriptler/hashifyAllScmTriggers.groovy
@@ -4,12 +4,14 @@
   "parameters" : [ "dry" ],
   "core": "1.511",
   "authors" : [
-    { "name" : "Wisen Tanasa" }
+    { "name" : "Wisen Tanasa" },
+    { "name" : "Benjamin Francisoud" }
   ]
 } END META**/
-import hudson.scheduler.*;
+import hudson.scheduler.*
 import hudson.model.*
 import hudson.triggers.*
+import hudson.scm.*
 
 dry = dry.toBoolean()
 println "Dry mode: $dry. \n"
@@ -17,7 +19,9 @@ println "Dry mode: $dry. \n"
 TriggerDescriptor SCM_TRIGGER_DESCRIPTOR = Hudson.instance.getDescriptorOrDie(SCMTrigger.class)
 assert SCM_TRIGGER_DESCRIPTOR != null;
 
-for(item in Hudson.instance.items) {
+items = Hudson.instance.items.findAll{job -> (!(job instanceof hudson.model.ExternalJob) && (job.scm instanceof SubversionSCM) && job.disabled == false) }
+
+for(item in items) {
   def trigger = item.getTriggers().get(SCM_TRIGGER_DESCRIPTOR)
   if(trigger != null && trigger instanceof SCMTrigger) {
     def newSpec = CronTab.hashify(trigger.spec)


### PR DESCRIPTION
hashifyAllScmTriggers fail on ExternalJob #48
```
!(job instanceof hudson.model.ExternalJob) && 
(job.scm instanceof SubversionSCM) && 
job.disabled == false
```