### PR TITLE
Update purgeOldBuilds.groovy

### DIFF
--- a/scriptler/purgeOldBuilds.groovy
+++ b/scriptler/purgeOldBuilds.groovy
@@ -9,4 +9,5 @@
 } END META**/
 
 
-jenkins.model.Jenkins.instance.items.each { it.logRotate() }
+jenkins.model.Jenkins.instance.items.findAll
+{job -> job.isBuildable() && job.hasProperty('logRotator') && job.logRotator!=null}.each { it.logRotate() }


### PR DESCRIPTION
Only call logRotate if it's going to be there - fixes operation with OrganizationFolders, etc.
Fix inspired by `discardOldBuilds.groovy` but needed the extra `hasProperty` to avoid tripping
on OrganizationFolder