### PR TITLE
Added scripts to get and set next build numbers

### DIFF
--- a/scriptler/getNextBuildNumbers.groovy
+++ b/scriptler/getNextBuildNumbers.groovy
@@ -1,0 +1,58 @@
+/*** BEGIN META {
+ "name" : "Print next build numbers for all jobs",
+ "comment" : "This script ouputs a JSON-formatted listing of the next build numbers for all jobs recursively. If you are interested in only a subset of the jobs, please specify the root folder explicitly. The output JSON can be captured in a file, copied over to another Jenkins server and used with the setNextBuildNumbers.groovy script. The idea is to ensure that build numbers do not get reset to 1 when migrating jobs from one Jenkins server to another.",
+ "parameters" : ['rootItem'],
+ "core": "1.625",
+ "authors" : [
+ { name : "Amit Modak" }
+ ]
+ } END META**/
+
+import jenkins.model.*
+
+def getBuildNumber(def item, def node) {
+
+  if(item instanceof com.cloudbees.hudson.plugins.folder.Folder) {
+    node[item.getName()] = [:] 
+    item.getItems().each {
+      getBuildNumber(it, node[item.getName()])
+    }   
+  } else {
+    node[item.getName()] = item.nextBuildNumber
+  }
+}
+
+//
+// main
+//
+
+def root = [:] 
+def node = root
+
+if(rootItem) {
+
+  if(Jenkins.instance.getItemByFullName(rootItem) && (Jenkins.instance.getItemByFullName(rootItem) instanceof com.cloudbees.hudson.plugins.folder.Folder)) {
+  
+    rootItem.split('/').each {
+      node[it] = [:] 
+      node = node[it]
+    }   
+  
+    Jenkins.instance.getItemByFullName(rootItem).getItems().each {
+      getBuildNumber(it, node)
+    }   
+  
+  } else {
+    println "Error: '" + rootItem + "' does not exist or is not a folder"
+    return
+  }
+
+} else {
+
+  Jenkins.instance.getItems().each {
+    getBuildNumber(it, node)
+  }
+}
+
+def output = groovy.json.JsonOutput.toJson(root)
+println groovy.json.JsonOutput.prettyPrint(output)

--- a/scriptler/interruptPollingThreads.groovy
+++ b/scriptler/interruptPollingThreads.groovy
@@ -1,7 +1,7 @@
 /*** BEGIN META {
  "name" : "Interrupt Polling Threads",
  "comment" : "Interrupt Polling Threads running for a certain amount of time. Script based on a comment in JENKINS-5413.",
- "parameters" : [ duration ],
+ "parameters" : [ 'duration' ],
  "core": "1.609",
  "authors" : [
  { name : "Allan Burdajewicz" }

--- a/scriptler/pluginDependenciesReport.groovy
+++ b/scriptler/pluginDependenciesReport.groovy
@@ -1,7 +1,7 @@
 /*** BEGIN META {
  "name" : "Plugin Dependencies Report",
  "comment" : "Get information about direct and recursive (JSON object) dependencies of/to a specific plugin.",
- "parameters" : [ pluginShortName ],
+ "parameters" : [ 'pluginShortName' ],
  "core": "1.609",
  "authors" : [
  { name : "Allan Burdajewicz" }

--- a/scriptler/setNextBuildNumbers.groovy
+++ b/scriptler/setNextBuildNumbers.groovy
@@ -1,0 +1,66 @@
+/*** BEGIN META {
+ "name" : "Print next build numbers for all jobs",
+ "comment" : "This script consumes a JSON-formatted input file the lists the next build numbers for a collection of jobs and sets the next build numbers of matching jobs as per the input file. The input JSON can be generated using the getNextBuildNumbers.groovy script. The idea is to ensure that build numbers do not get reset to 1 when migrating jobs from one Jenkins server to another.",
+ "parameters" : ['inputFilePath'],
+ "core": "1.625",
+ "authors" : [
+ { name : "Amit Modak" }
+ ]
+ } END META**/
+
+import jenkins.model.*
+
+def setBuildNumber(def key, def value, def path = []) {
+
+  path.push(key)
+  if(value instanceof java.util.Map) {
+    value.each { k, v ->
+      setBuildNumber(k, v, path)
+    }
+
+  } else {
+    jobName = path.join('/')
+    job = Jenkins.instance.getItemByFullName(jobName)
+
+    if(job && !(job instanceof com.cloudbees.hudson.plugins.folder.Folder)) {
+      
+      //println "Setting build number for " + jobName + " to " + value
+      job.nextBuildNumber = value
+      job.saveNextBuildNumber()
+
+    } else {
+      println "Warning: Failed to set next build number for '" + jobName + "'"
+    }
+  }
+  path.pop()
+}
+
+//
+// main
+//
+
+if(!inputFilePath) {
+
+  println "Error: Please specify inputFilePath and retry"
+  return
+
+}
+
+try {
+
+  String input = new File(inputFilePath).getText('UTF-8')
+
+  def jsonSlurper = new groovy.json.JsonSlurper()
+  def root = jsonSlurper.parseText(input)
+
+  root.each { k, v ->
+    setBuildNumber(k, v)
+  }
+
+} catch (java.io.FileNotFoundException e) {
+  println "Error: Could not open " + inputFilePath + " for reading"
+
+} catch (groovy.json.JsonException e) {
+  println "Error: Failed to parse " + inputFilePath
+
+}


### PR DESCRIPTION
## Overview
This pull-request adds a pair of scripts - `getNextBuildNumbers.groovy` and `setNextBuildNumbers.groovy`. The former can be used to obtain the next build numbers for all jobs on a Jenkins server while the latter can be used to set the next build numbers for all jobs. These scripts can be used to ensure that build numbers are retained while migrating jobs from one Jenkins server to another. 

### getNextBuildNumbers.groovy
Prints a JSON-formatted listing of next build numbers of all jobs recursively. If you are interested in only a subset of the jobs, please specify the `rootItem` explicitly. The output JSON can be captured in a file, copied over to another Jenkins server and used with the `setNextBuildNumbers.groovy` script. The idea is to ensure that build numbers do not get reset to 1 when migrating jobs from one Jenkins server to another.

Sample Output
```
{
    "top folder": {
        "foo 1": {
            "foo job": 1
        },
        "foo 2": {
            "bar job": 3
        }
    }
}
```

This output indicates that next build numbers for jobs `top folder/foo 1/foo job` and `top folder/foo 2/bar job` are both `1` and `3` respectively.

### setNextBuildNumbers.groovy
This script consumes the JSON-formatted file generated by 'getNextBuildNumbers.groovy` (needs to be specified as a file-system path) and sets the next build numbers of matching jobs as per the input file. The idea is to ensure that build numbers do not get reset to 1 when migrating jobs from one Jenkins server to another.

## Miscellaneous
This pull-request also fixes a couple of minor META format issues in unrelated scripts.