### PR TITLE
Fix script for SCMedItem implementations

### DIFF
--- a/scriptler/interruptPollingThreads.groovy
+++ b/scriptler/interruptPollingThreads.groovy
@@ -14,17 +14,17 @@ import jenkins.model.Jenkins
  * Interrupt any running Polling Threads that are currently running for more than `duration` seconds. This can be tuned.
  */
 Jenkins.instance.getTrigger("SCMTrigger").getRunners().each() {
-    item ->
-        println(item.getTarget().name)
-        println(item.getDuration())
-        println(item.getStartTime())
-        long millis = Calendar.instance.time.time - item.getStartTime()
+    runner ->
+        println(runner.getTarget().asItem().name)
+        println(runner.getDuration())
+        println(runner.getStartTime())
+        long millis = Calendar.instance.time.time - runner.getStartTime()
 
         if (millis > (1000 * Integer.parseInt(duration))) {
             Thread.getAllStackTraces().keySet().each() {
                 tItem ->
-                    if (tItem.getName().contains("SCM polling") && tItem.getName().contains(item.getTarget().name)) {
-                        println "Interrupting thread " + tItem.getId() + " " + tItem.getName();
+                    if (tItem.getName().contains("SCM polling") && tItem.getName().contains(runner.getTarget().asItem().name)) {
+                        println "Interrupting thread " + tItem.getId() + " " + tItem.getName()
                         tItem.interrupt()
                     }
             }


### PR DESCRIPTION
Recently discovered that this script fails on `item.getTarget().name` where the _target_ is a [Bridge](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/triggers/SCMTriggerItem.java#L120) (indirectly a [SCMedItem](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/triggers/SCMTriggerItem.java#L113) implementation).

Fixed this by explicitly calling `asItem()` on the _Runner_.