### PR TITLE
wipeout-workspace.groovy: Support for nested project structure

### DIFF
--- a/scriptler/wipeout-workspace.groovy
+++ b/scriptler/wipeout-workspace.groovy
@@ -8,16 +8,13 @@
   ]
 } END META**/
 // For each project
-for(item in jenkins.model.Jenkins.instance.items) {
-  // check that job is not building
-  if(!item.isBuilding()) {
-    println("Wiping out workspace of job "+item.name)
-    if (!"true".equals(dryRun)) {
-      item.doDoWipeOutWorkspace()
+jenkins.model.Jenkins.instance.getAllItems(hudson.model.AbstractProject).each { job ->
+  if (job.building) {
+    println "Skipping job $job.name, currently building"
+  } else {
+    println "Wiping out workspace of $job.name"
+    if (dryRun != 'true') {
+      job.doDoWipeOutWorkspace()
     }
   }
-  else {
-    println("Skipping job "+item.name+", currently building")
-  }
 }
-


### PR DESCRIPTION
The current version of the script do not ascend into [Folders](https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin) causing the script execution to fail. The fix supports nested project directory structure as well.