### PR TITLE
Add FolderCredentialsProperty if missing from folder

### DIFF
--- a/scriptler/addCredentialsToFolder.groovy
+++ b/scriptler/addCredentialsToFolder.groovy
@@ -22,8 +22,10 @@ Jenkins.instance.getAllItems(Folder.class)
     .each{
         AbstractFolder<?> folderAbs = AbstractFolder.class.cast(it)
         FolderCredentialsProperty property = folderAbs.getProperties().get(FolderCredentialsProperty.class)
-        if(property != null){
-            property.getStore().addCredentials(Domain.global(), c)
-            println property.getCredentials().toString()
+        if (property == null) {
+            property = new FolderCredentialsProperty()
+            folderAbs.addProperty(property)
         }
+        property.getStore().addCredentials(Domain.global(), c)
+        println property.getCredentials().toString()
     }


### PR DESCRIPTION
Script fails to add the credential if the folder has not already had a credential added to it.

Thanks to @Dohbedoh for the fix in his comment on cloudbees.com.