### PR TITLE
https://issues.jenkins-ci.org/browse/JENKINS-24031 fix empty remote tab

### DIFF
--- a/scriptler/listEC2Instances.groovy
+++ b/scriptler/listEC2Instances.groovy
@@ -1,7 +1,7 @@
 /*** BEGIN META {
  "name" : "List EC2 Cloud instances",
  "comment" : "Iterate all EC2 Clouds and every template on them, to list the instances running",
- "parameters" : "",
+ "parameters" : [],
  "core": "2.32",
  "authors" : [{ name : "kuisathaverat" }]
  } END META**/


### PR DESCRIPTION
parameters should be an array [], not a string ""
related to https://issues.jenkins-ci.org/browse/JENKINS-24031
The "GitHub" tab in the "Remote Script catalogs" is not populated 
Error log shows:
Can't transform property 'parameters' from java.lang.String into java.util.List. Will register a default Morpher